### PR TITLE
Update V2__create_test_stations.sql to include additional fields for …

### DIFF
--- a/src/main/resources/db/migration/V2__create_test_stations.sql
+++ b/src/main/resources/db/migration/V2__create_test_stations.sql
@@ -1,7 +1,22 @@
 -- Insert test charging stations along Porto to Lisbon route
-INSERT INTO stations (name, address, city, country, latitude, longitude, connector_type, status, power, is_operational, price) VALUES
-('Porto Central Station', 'Rua Central 123', 'Porto', 'Portugal', 41.1579, -8.6291, 'Type 2', 'Available', 50, true, 0.25),
-('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', 'Portugal', 40.6443, -8.6455, 'CCS', 'Available', 150, true, 0.30),
-('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', 'Portugal', 40.2033, -8.4103, 'Tesla', 'Available', 250, true, 0.35),
-('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', 'Portugal', 39.7477, -8.8070, 'Type 2', 'Available', 100, true, 0.28),
-('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', 'Portugal', 38.7223, -9.1393, 'CCS', 'Available', 150, true, 0.30); 
+INSERT INTO stations (
+    name, 
+    address, 
+    city, 
+    country, 
+    latitude, 
+    longitude, 
+    status, 
+    quantity_of_chargers,
+    power,
+    is_operational, 
+    price,
+    number_of_chargers,
+    min_power,
+    max_power
+) VALUES
+('Porto Central Station', 'Rua Central 123', 'Porto', 'Portugal', 41.1579, -8.6291, 'Available', 2, 50, true, 0.25, 2, 22, 50),
+('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', 'Portugal', 40.6443, -8.6455, 'Available', 3, 150, true, 0.30, 3, 50, 150),
+('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', 'Portugal', 40.2033, -8.4103, 'Available', 4, 250, true, 0.35, 4, 150, 250),
+('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', 'Portugal', 39.7477, -8.8070, 'Available', 2, 100, true, 0.28, 2, 50, 100),
+('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', 'Portugal', 38.7223, -9.1393, 'Available', 3, 150, true, 0.30, 3, 50, 150); 


### PR DESCRIPTION
This pull request updates the database migration file for test charging stations to include additional details about chargers and power ranges. The changes enhance the schema by adding new columns and updating the data accordingly.

Database schema enhancements:

* [`src/main/resources/db/migration/V2__create_test_stations.sql`](diffhunk://#diff-e7d6df2f4efb93797c0b3388410d1e38c3840963161d95771bc91b04e58f2480L2-R22): Added new columns `quantity_of_chargers`, `number_of_chargers`, `min_power`, and `max_power` to the `stations` table. Updated the `INSERT` statements to include values for these columns, providing more granular information about the charging stations.