### PR TITLE
Update/release v1.0.0 with dev

### DIFF
--- a/src/main/java/tqs/sparkflow/stationservice/model/Station.java
+++ b/src/main/java/tqs/sparkflow/stationservice/model/Station.java
@@ -8,9 +8,9 @@ import jakarta.persistence.Inheritance;
 import jakarta.persistence.InheritanceType;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.persistence.Column;
+import java.util.Objects;
 
 /** Represents a charging station. */
 @Entity
@@ -166,6 +166,25 @@ public class Station extends BaseStationFields {
   @Override
   public String toString() {
     return "Station{id=" + id + ", name='" + name + "'}";
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o)
+      return true;
+    if (o == null || getClass() != o.getClass())
+      return false;
+    if (!super.equals(o))
+      return false;
+    Station station = (Station) o;
+    return Objects.equals(id, station.id) && Objects.equals(externalId, station.externalId)
+        && Objects.equals(power, station.power)
+        && Objects.equals(quantityOfChargers, station.quantityOfChargers);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(super.hashCode(), id, externalId, power, quantityOfChargers);
   }
 
   /**

--- a/src/main/java/tqs/sparkflow/stationservice/repository/BookingRepository.java
+++ b/src/main/java/tqs/sparkflow/stationservice/repository/BookingRepository.java
@@ -2,6 +2,7 @@ package tqs.sparkflow.stationservice.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,30 +11,31 @@ import tqs.sparkflow.stationservice.model.Booking;
 
 @Repository
 public interface BookingRepository extends JpaRepository<Booking, Long> {
-  @Query("SELECT b FROM Booking b WHERE b.stationId = :stationId AND b.status = 'ACTIVE' "
-      + "AND ((b.startTime <= :endTime AND b.endTime >= :startTime))")
-  List<Booking> findOverlappingBookings(@Param("stationId") Long stationId,
-      @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
+    @Query("SELECT b FROM Booking b WHERE b.stationId = :stationId AND b.status = 'ACTIVE' "
+            + "AND ((b.startTime <= :endTime AND b.endTime >= :startTime) "
+            + "OR (b.startTime >= :startTime AND b.startTime < :endTime) "
+            + "OR (b.endTime > :startTime AND b.endTime <= :endTime))")
+    List<Booking> findOverlappingBookings(@Param("stationId") Long stationId,
+            @Param("startTime") LocalDateTime startTime, @Param("endTime") LocalDateTime endTime);
 
-  @Query("SELECT b FROM Booking b WHERE b.stationId = :stationId AND b.status = 'ACTIVE' "
-      + "AND b.startTime <= :currentTime AND b.endTime >= :currentTime")
-  List<Booking> findActiveBookingsForStationAtTime(@Param("stationId") Long stationId,
-      @Param("currentTime") LocalDateTime currentTime);
+    @Query("SELECT b FROM Booking b WHERE b.stationId = :stationId AND b.status = 'ACTIVE' "
+            + "AND b.startTime <= :currentTime AND b.endTime >= :currentTime")
+    List<Booking> findActiveBookingsForStationAtTime(@Param("stationId") Long stationId,
+            @Param("currentTime") LocalDateTime currentTime);
 
-  List<Booking> findByStationId(Long stationId);
+    List<Booking> findByStationId(Long stationId);
 
-  List<Booking> findByUserId(Long userId);
+    List<Booking> findByUserId(Long userId);
 
-  @Query("SELECT b FROM Booking b WHERE b.stationId = :stationId AND b.userId = :userId")
-  List<Booking> findByStationIdAndUserId(@Param("stationId") Long stationId, @Param("userId") Long userId);
+    @Query("SELECT b FROM Booking b WHERE b.stationId = :stationId AND b.userId = :userId")
+    List<Booking> findByStationIdAndUserId(@Param("stationId") Long stationId,
+            @Param("userId") Long userId);
 
-  /**
-   * Find bookings for a specific user within a time range.
-   */
-  @Query("SELECT b FROM Booking b WHERE b.userId = :userId " +
-         "AND b.startTime >= :startDate AND b.startTime <= :endDate")
-  List<Booking> findBookingsByUserInPeriod(
-          @Param("userId") String userId,
-          @Param("startDate") LocalDateTime startDate,
-          @Param("endDate") LocalDateTime endDate);
-} 
+    /**
+     * Find bookings for a specific user within a time range.
+     */
+    @Query("SELECT b FROM Booking b WHERE b.userId = :userId "
+            + "AND b.startTime >= :startDate AND b.startTime <= :endDate")
+    List<Booking> findBookingsByUserInPeriod(@Param("userId") String userId,
+            @Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+}

--- a/src/main/java/tqs/sparkflow/stationservice/repository/BookingRepository.java
+++ b/src/main/java/tqs/sparkflow/stationservice/repository/BookingRepository.java
@@ -2,7 +2,6 @@ package tqs.sparkflow.stationservice.repository;
 
 import java.time.LocalDateTime;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;

--- a/src/main/java/tqs/sparkflow/stationservice/service/BookingServiceImpl.java
+++ b/src/main/java/tqs/sparkflow/stationservice/service/BookingServiceImpl.java
@@ -4,41 +4,45 @@ import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.client.RestTemplate;
 import tqs.sparkflow.stationservice.model.Booking;
 import tqs.sparkflow.stationservice.model.BookingStatus;
 import tqs.sparkflow.stationservice.model.Station;
 import tqs.sparkflow.stationservice.repository.BookingRepository;
+import tqs.sparkflow.stationservice.repository.StationRepository;
 
 @Service
 public class BookingServiceImpl implements BookingService {
+  @Value("${api.paths.users}")
+  private String usersPath;
+
   private final BookingRepository bookingRepository;
-  private final StationService stationService;
+  private final StationRepository stationRepository;
   private final RestTemplate restTemplate;
   private final String userServiceUrl;
-  private static final String USERS_PATH = "/users/";
   private static final String ADMIN_ROLE_CHECK = "/has-role/ADMIN";
 
   /**
    * Creates a new instance of BookingServiceImpl.
    *
    * @param bookingRepository The repository for booking operations
-   * @param stationService The service for station operations
+   * @param stationRepository The repository for station operations
    * @param restTemplate The RestTemplate for making HTTP requests
    * @param userServiceUrl The URL of the user service
    */
-  public BookingServiceImpl(BookingRepository bookingRepository, StationService stationService,
-      RestTemplate restTemplate, String userServiceUrl) {
+  public BookingServiceImpl(BookingRepository bookingRepository,
+      StationRepository stationRepository, RestTemplate restTemplate, String userServiceUrl) {
     this.bookingRepository = bookingRepository;
-    this.stationService = stationService;
+    this.stationRepository = stationRepository;
     this.restTemplate = restTemplate;
     this.userServiceUrl = userServiceUrl;
   }
 
   private void validateUser(Long userId) {
     try {
-      restTemplate.getForObject(userServiceUrl + USERS_PATH + userId, Object.class);
+      restTemplate.getForObject(userServiceUrl + usersPath + userId, Object.class);
     } catch (Exception e) {
       throw new IllegalStateException("User not found or not authorized");
     }
@@ -47,7 +51,7 @@ public class BookingServiceImpl implements BookingService {
   private void validateUserPermission(Long userId, Long bookingUserId) {
     if (!userId.equals(bookingUserId)) {
       try {
-        restTemplate.getForObject(userServiceUrl + USERS_PATH + userId + ADMIN_ROLE_CHECK,
+        restTemplate.getForObject(userServiceUrl + usersPath + userId + ADMIN_ROLE_CHECK,
             Boolean.class);
       } catch (Exception e) {
         throw new IllegalStateException("User not authorized to access this booking");
@@ -60,12 +64,19 @@ public class BookingServiceImpl implements BookingService {
       LocalDateTime endTime, Set<Integer> recurringDays) {
     validateUser(userId);
 
-    Station station = stationService.getStationById(stationId);
+    Station station = stationRepository.findById(stationId)
+        .orElseThrow(() -> new IllegalStateException("Station not found"));
     if (Boolean.FALSE.equals(station.getIsOperational())) {
       throw new IllegalStateException("Station is not operational");
     }
 
-    stationService.validateBooking(stationId, userId, startTime, endTime);
+    // Check for overlapping bookings
+    List<Booking> overlappingBookings =
+        bookingRepository.findOverlappingBookings(stationId, startTime, endTime);
+
+    if (!overlappingBookings.isEmpty()) {
+      throw new IllegalStateException("There are overlapping bookings for this time slot");
+    }
 
     Booking booking = new Booking();
     booking.setUserId(userId);
@@ -98,7 +109,7 @@ public class BookingServiceImpl implements BookingService {
   public List<Booking> getAllBookings(Long userId) {
     validateUser(userId);
     try {
-      restTemplate.getForObject(userServiceUrl + USERS_PATH + userId + ADMIN_ROLE_CHECK,
+      restTemplate.getForObject(userServiceUrl + usersPath + userId + ADMIN_ROLE_CHECK,
           Boolean.class);
     } catch (Exception e) {
       throw new IllegalStateException("User not authorized to access all bookings");
@@ -124,7 +135,7 @@ public class BookingServiceImpl implements BookingService {
   public List<Booking> getBookingsByStationId(Long stationId, Long requestingUserId) {
     validateUser(requestingUserId);
     try {
-      restTemplate.getForObject(userServiceUrl + USERS_PATH + requestingUserId + ADMIN_ROLE_CHECK,
+      restTemplate.getForObject(userServiceUrl + usersPath + requestingUserId + ADMIN_ROLE_CHECK,
           Boolean.class);
     } catch (Exception e) {
       // If not admin, only return bookings for this user

--- a/src/main/java/tqs/sparkflow/stationservice/service/OpenChargeMapService.java
+++ b/src/main/java/tqs/sparkflow/stationservice/service/OpenChargeMapService.java
@@ -199,7 +199,21 @@ public class OpenChargeMapService {
   }
 
   private Number getNumber(Object obj) {
+    if (obj == null) {
+      return 0;
+    }
     return (Number) obj;
+  }
+
+  private boolean isString(Object obj) {
+    return obj instanceof String;
+  }
+
+  private String getString(Object obj) {
+    if (obj == null) {
+      return "";
+    }
+    return (String) obj;
   }
 
   private void setStationName(Map<String, Object> addressInfo, Station station) {
@@ -251,10 +265,9 @@ public class OpenChargeMapService {
       if (quantity != null) {
         if (isNumber(quantity)) {
           totalChargers += getNumber(quantity).intValue();
-        } else if (quantity instanceof String) {
-          String string = (String) quantity;
+        } else if (isString(quantity)) {
           try {
-            totalChargers += Integer.parseInt(string);
+            totalChargers += Integer.parseInt(getString(quantity));
           } catch (NumberFormatException e) {
             // If parsing fails, count as 1
             totalChargers += 1;

--- a/src/main/java/tqs/sparkflow/stationservice/service/OpenChargeMapService.java
+++ b/src/main/java/tqs/sparkflow/stationservice/service/OpenChargeMapService.java
@@ -188,7 +188,8 @@ public class OpenChargeMapService {
   private void setStationId(Map<String, Object> data, Station station) {
     Object id = data.get("ID");
     if (id instanceof Number) {
-      station.setId(((Number) id).longValue());
+      Number number = (Number) id;
+      station.setId(number.longValue());
     } else if (id != null) {
       station.setId(Long.parseLong(id.toString()));
     }
@@ -207,8 +208,18 @@ public class OpenChargeMapService {
   private void setStationCoordinates(Map<String, Object> addressInfo, Station station) {
     Object lat = addressInfo != null ? addressInfo.get("Latitude") : null;
     Object lon = addressInfo != null ? addressInfo.get("Longitude") : null;
-    station.setLatitude(lat != null ? ((Number) lat).doubleValue() : 0.0);
-    station.setLongitude(lon != null ? ((Number) lon).doubleValue() : 0.0);
+    if (lat instanceof Number) {
+      Number number = (Number) lat;
+      station.setLatitude(number.doubleValue());
+    } else {
+      station.setLatitude(0.0);
+    }
+    if (lon instanceof Number) {
+      Number number = (Number) lon;
+      station.setLongitude(number.doubleValue());
+    } else {
+      station.setLongitude(0.0);
+    }
   }
 
   private void setStationCity(Map<String, Object> addressInfo, Station station) {
@@ -234,10 +245,12 @@ public class OpenChargeMapService {
       Object quantity = connection.get("Quantity");
       if (quantity != null) {
         if (quantity instanceof Number) {
-          totalChargers += ((Number) quantity).intValue();
+          Number number = (Number) quantity;
+          totalChargers += number.intValue();
         } else if (quantity instanceof String) {
+          String string = (String) quantity;
           try {
-            totalChargers += Integer.parseInt((String) quantity);
+            totalChargers += Integer.parseInt(string);
           } catch (NumberFormatException e) {
             // If parsing fails, count as 1
             totalChargers += 1;

--- a/src/main/java/tqs/sparkflow/stationservice/service/OpenChargeMapService.java
+++ b/src/main/java/tqs/sparkflow/stationservice/service/OpenChargeMapService.java
@@ -187,12 +187,19 @@ public class OpenChargeMapService {
 
   private void setStationId(Map<String, Object> data, Station station) {
     Object id = data.get("ID");
-    if (id instanceof Number) {
-      Number number = (Number) id;
-      station.setId(number.longValue());
+    if (isNumber(id)) {
+      station.setId(getNumber(id).longValue());
     } else if (id != null) {
       station.setId(Long.parseLong(id.toString()));
     }
+  }
+
+  private boolean isNumber(Object obj) {
+    return obj instanceof Number;
+  }
+
+  private Number getNumber(Object obj) {
+    return (Number) obj;
   }
 
   private void setStationName(Map<String, Object> addressInfo, Station station) {
@@ -208,15 +215,13 @@ public class OpenChargeMapService {
   private void setStationCoordinates(Map<String, Object> addressInfo, Station station) {
     Object lat = addressInfo != null ? addressInfo.get("Latitude") : null;
     Object lon = addressInfo != null ? addressInfo.get("Longitude") : null;
-    if (lat instanceof Number) {
-      Number number = (Number) lat;
-      station.setLatitude(number.doubleValue());
+    if (isNumber(lat)) {
+      station.setLatitude(getNumber(lat).doubleValue());
     } else {
       station.setLatitude(0.0);
     }
-    if (lon instanceof Number) {
-      Number number = (Number) lon;
-      station.setLongitude(number.doubleValue());
+    if (isNumber(lon)) {
+      station.setLongitude(getNumber(lon).doubleValue());
     } else {
       station.setLongitude(0.0);
     }
@@ -244,9 +249,8 @@ public class OpenChargeMapService {
       // Get quantity from connection
       Object quantity = connection.get("Quantity");
       if (quantity != null) {
-        if (quantity instanceof Number) {
-          Number number = (Number) quantity;
-          totalChargers += number.intValue();
+        if (isNumber(quantity)) {
+          totalChargers += getNumber(quantity).intValue();
         } else if (quantity instanceof String) {
           String string = (String) quantity;
           try {

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -56,3 +56,6 @@ route.planning.min-battery-percentage=0.2
 route.planning.max-battery-percentage=0.8
 route.planning.max-detour-distance=20.0
 route.planning.requests-per-second=10.0
+
+# API Paths
+api.paths.users=/users/

--- a/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -313,13 +314,13 @@ class StationTest {
     station1.setStatus("Available");
 
     // Test same object
-    assertTrue(station1.equals(station1));
+    assertEquals(station1, station1);
 
     // Test null
-    assertFalse(station1.equals(null));
+    assertNotEquals(station1, null);
 
     // Test different class
-    assertFalse(station1.equals("Not a Station"));
+    assertNotEquals(station1, "Not a Station");
 
     // Test different id
     Station station2 = new Station();
@@ -335,7 +336,7 @@ class StationTest {
     station2.setLatitude(station1.getLatitude());
     station2.setLongitude(station1.getLongitude());
     station2.setStatus(station1.getStatus());
-    assertFalse(station1.equals(station2));
+    assertNotEquals(station1, station2);
 
     // Test different externalId
     Station station3 = new Station();
@@ -367,7 +368,7 @@ class StationTest {
     station4.setLatitude(station1.getLatitude());
     station4.setLongitude(station1.getLongitude());
     station4.setStatus(station1.getStatus());
-    assertFalse(station1.equals(station4));
+    assertNotEquals(station1, station4);
 
     // Test different quantityOfChargers
     Station station5 = new Station();
@@ -383,7 +384,7 @@ class StationTest {
     station5.setLatitude(station1.getLatitude());
     station5.setLongitude(station1.getLongitude());
     station5.setStatus(station1.getStatus());
-    assertFalse(station1.equals(station5));
+    assertNotEquals(station1, station5);
 
     // Test equal stations
     Station station6 = new Station();
@@ -430,7 +431,7 @@ class StationTest {
     station8.setLongitude(station1.getLongitude());
     station8.setStatus(station1.getStatus());
 
-    assertTrue(station7.equals(station8));
+    assertEquals(station7, station8);
   }
 
   @Test

--- a/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
@@ -300,12 +300,12 @@ class StationTest {
   @DisplayName("equals should return false when comparing with null")
   void whenComparingWithNull_thenReturnFalse() {
     // Given
-    Station station = new Station();
+    Station testStation = new Station();
     station.setId(1L);
     station.setName("Test Station");
 
     // When
-    boolean result = station.equals(null);
+    boolean result = testStation.equals(null);
 
     // Then
     assertThat(result).isFalse();
@@ -315,14 +315,14 @@ class StationTest {
   @DisplayName("equals should return false when comparing with different class")
   void whenComparingWithDifferentClass_thenReturnFalse() {
     // Given
-    Station station = new Station();
-    station.setId(1L);
-    station.setName("Test Station");
+    Station testStation = new Station();
+    testStation.setId(1L);
+    testStation.setName("Test Station");
 
     Object otherObject = new Object();
 
     // When
-    boolean result = station.equals(otherObject);
+    boolean result = testStation.equals(otherObject);
 
     // Then
     assertThat(result).isFalse();
@@ -332,12 +332,12 @@ class StationTest {
   @DisplayName("equals should return true when comparing with same instance")
   void whenComparingWithSameInstance_thenReturnTrue() {
     // Given
-    Station station = new Station();
-    station.setId(1L);
-    station.setName("Test Station");
+    Station testStation = new Station();
+    testStation.setId(1L);
+    testStation.setName("Test Station");
 
     // When
-    boolean result = station.equals(station);
+    boolean result = testStation.equals(testStation);
 
     // Then
     assertThat(result).isTrue();

--- a/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
@@ -2,8 +2,6 @@ package tqs.sparkflow.stationservice.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import jakarta.validation.Validation;

--- a/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
@@ -11,6 +11,7 @@ import jakarta.validation.Validator;
 import jakarta.validation.ValidatorFactory;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
 
 class StationTest {
 
@@ -298,140 +299,100 @@ class StationTest {
   }
 
   @Test
-  void testEquals() {
+  @DisplayName("equals should return false when comparing with null")
+  void whenComparingWithNull_thenReturnFalse() {
+    // Given
+    Station station = new Station();
+    station.setId(1L);
+    station.setName("Test Station");
+
+    // When
+    boolean result = station.equals(null);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("equals should return false when comparing with different class")
+  void whenComparingWithDifferentClass_thenReturnFalse() {
+    // Given
+    Station station = new Station();
+    station.setId(1L);
+    station.setName("Test Station");
+
+    Object otherObject = new Object();
+
+    // When
+    boolean result = station.equals(otherObject);
+
+    // Then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  @DisplayName("equals should return true when comparing with same instance")
+  void whenComparingWithSameInstance_thenReturnTrue() {
+    // Given
+    Station station = new Station();
+    station.setId(1L);
+    station.setName("Test Station");
+
+    // When
+    boolean result = station.equals(station);
+
+    // Then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  @DisplayName("equals should return true when comparing with equal station")
+  void whenComparingWithEqualStation_thenReturnTrue() {
+    // Given
     Station station1 = new Station();
     station1.setId(1L);
+    station1.setName("Test Station");
     station1.setExternalId("ext1");
     station1.setPower(50);
     station1.setQuantityOfChargers(2);
-    // Set base fields to ensure super.equals() passes
-    station1.setName("Test Station");
-    station1.setAddress("Test Address");
-    station1.setCity("Test City");
-    station1.setCountry("Test Country");
-    station1.setLatitude(40.0);
-    station1.setLongitude(-8.0);
-    station1.setStatus("Available");
 
-    // Test same object
-    assertEquals(station1, station1);
-
-    // Test null
-    assertNotEquals(null, station1);
-
-    // Test different class
-    assertNotEquals("Not a Station", station1);
-
-    // Test different id
     Station station2 = new Station();
-    station2.setId(2L);
+    station2.setId(1L);
+    station2.setName("Test Station");
     station2.setExternalId("ext1");
     station2.setPower(50);
     station2.setQuantityOfChargers(2);
-    // Copy base fields
-    station2.setName(station1.getName());
-    station2.setAddress(station1.getAddress());
-    station2.setCity(station1.getCity());
-    station2.setCountry(station1.getCountry());
-    station2.setLatitude(station1.getLatitude());
-    station2.setLongitude(station1.getLongitude());
-    station2.setStatus(station1.getStatus());
-    assertNotEquals(station1, station2);
 
-    // Test different externalId
-    Station station3 = new Station();
-    station3.setId(1L);
-    station3.setExternalId("ext2");
-    station3.setPower(50);
-    station3.setQuantityOfChargers(2);
-    // Copy base fields
-    station3.setName(station1.getName());
-    station3.setAddress(station1.getAddress());
-    station3.setCity(station1.getCity());
-    station3.setCountry(station1.getCountry());
-    station3.setLatitude(station1.getLatitude());
-    station3.setLongitude(station1.getLongitude());
-    station3.setStatus(station1.getStatus());
-    assertNotEquals(station1, station3);
+    // When
+    boolean result = station1.equals(station2);
 
-    // Test different power
-    Station station4 = new Station();
-    station4.setId(1L);
-    station4.setExternalId("ext1");
-    station4.setPower(100);
-    station4.setQuantityOfChargers(2);
-    // Copy base fields
-    station4.setName(station1.getName());
-    station4.setAddress(station1.getAddress());
-    station4.setCity(station1.getCity());
-    station4.setCountry(station1.getCountry());
-    station4.setLatitude(station1.getLatitude());
-    station4.setLongitude(station1.getLongitude());
-    station4.setStatus(station1.getStatus());
-    assertNotEquals(station1, station4);
+    // Then
+    assertThat(result).isTrue();
+  }
 
-    // Test different quantityOfChargers
-    Station station5 = new Station();
-    station5.setId(1L);
-    station5.setExternalId("ext1");
-    station5.setPower(50);
-    station5.setQuantityOfChargers(4);
-    // Copy base fields
-    station5.setName(station1.getName());
-    station5.setAddress(station1.getAddress());
-    station5.setCity(station1.getCity());
-    station5.setCountry(station1.getCountry());
-    station5.setLatitude(station1.getLatitude());
-    station5.setLongitude(station1.getLongitude());
-    station5.setStatus(station1.getStatus());
-    assertNotEquals(station1, station5);
+  @Test
+  @DisplayName("equals should return false when comparing with different station")
+  void whenComparingWithDifferentStation_thenReturnFalse() {
+    // Given
+    Station station1 = new Station();
+    station1.setId(1L);
+    station1.setName("Test Station 1");
+    station1.setExternalId("ext1");
+    station1.setPower(50);
+    station1.setQuantityOfChargers(2);
 
-    // Test equal stations
-    Station station6 = new Station();
-    station6.setId(1L);
-    station6.setExternalId("ext1");
-    station6.setPower(50);
-    station6.setQuantityOfChargers(2);
-    // Copy base fields
-    station6.setName(station1.getName());
-    station6.setAddress(station1.getAddress());
-    station6.setCity(station1.getCity());
-    station6.setCountry(station1.getCountry());
-    station6.setLatitude(station1.getLatitude());
-    station6.setLongitude(station1.getLongitude());
-    station6.setStatus(station1.getStatus());
-    assertEquals(station1, station6);
+    Station station2 = new Station();
+    station2.setId(2L);
+    station2.setName("Test Station 2");
+    station2.setExternalId("ext2");
+    station2.setPower(100);
+    station2.setQuantityOfChargers(4);
 
-    // Test null fields
-    Station station7 = new Station();
-    station7.setId(1L);
-    station7.setExternalId(null);
-    station7.setPower(null);
-    station7.setQuantityOfChargers(null);
-    // Copy base fields
-    station7.setName(station1.getName());
-    station7.setAddress(station1.getAddress());
-    station7.setCity(station1.getCity());
-    station7.setCountry(station1.getCountry());
-    station7.setLatitude(station1.getLatitude());
-    station7.setLongitude(station1.getLongitude());
-    station7.setStatus(station1.getStatus());
+    // When
+    boolean result = station1.equals(station2);
 
-    Station station8 = new Station();
-    station8.setId(1L);
-    station8.setExternalId(null);
-    station8.setPower(null);
-    station8.setQuantityOfChargers(null);
-    // Copy base fields
-    station8.setName(station1.getName());
-    station8.setAddress(station1.getAddress());
-    station8.setCity(station1.getCity());
-    station8.setCountry(station1.getCountry());
-    station8.setLatitude(station1.getLatitude());
-    station8.setLongitude(station1.getLongitude());
-    station8.setStatus(station1.getStatus());
-
-    assertEquals(station7, station8);
+    // Then
+    assertThat(result).isFalse();
   }
 
   @Test

--- a/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
@@ -1,6 +1,9 @@
 package tqs.sparkflow.stationservice.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;
@@ -291,5 +294,175 @@ class StationTest {
     assertThat(testStation.getPrice()).isNull();
     assertThat(testStation.getQuantityOfChargers()).isNull();
     assertThat(testStation.getStatus()).isNull();
+  }
+
+  @Test
+  void testEquals() {
+    Station station1 = new Station();
+    station1.setId(1L);
+    station1.setExternalId("ext1");
+    station1.setPower(50);
+    station1.setQuantityOfChargers(2);
+    // Set base fields to ensure super.equals() passes
+    station1.setName("Test Station");
+    station1.setAddress("Test Address");
+    station1.setCity("Test City");
+    station1.setCountry("Test Country");
+    station1.setLatitude(40.0);
+    station1.setLongitude(-8.0);
+    station1.setStatus("Available");
+
+    // Test same object
+    assertTrue(station1.equals(station1));
+
+    // Test null
+    assertFalse(station1.equals(null));
+
+    // Test different class
+    assertFalse(station1.equals("Not a Station"));
+
+    // Test different id
+    Station station2 = new Station();
+    station2.setId(2L);
+    station2.setExternalId("ext1");
+    station2.setPower(50);
+    station2.setQuantityOfChargers(2);
+    // Copy base fields
+    station2.setName(station1.getName());
+    station2.setAddress(station1.getAddress());
+    station2.setCity(station1.getCity());
+    station2.setCountry(station1.getCountry());
+    station2.setLatitude(station1.getLatitude());
+    station2.setLongitude(station1.getLongitude());
+    station2.setStatus(station1.getStatus());
+    assertFalse(station1.equals(station2));
+
+    // Test different externalId
+    Station station3 = new Station();
+    station3.setId(1L);
+    station3.setExternalId("ext2");
+    station3.setPower(50);
+    station3.setQuantityOfChargers(2);
+    // Copy base fields
+    station3.setName(station1.getName());
+    station3.setAddress(station1.getAddress());
+    station3.setCity(station1.getCity());
+    station3.setCountry(station1.getCountry());
+    station3.setLatitude(station1.getLatitude());
+    station3.setLongitude(station1.getLongitude());
+    station3.setStatus(station1.getStatus());
+    assertFalse(station1.equals(station3));
+
+    // Test different power
+    Station station4 = new Station();
+    station4.setId(1L);
+    station4.setExternalId("ext1");
+    station4.setPower(100);
+    station4.setQuantityOfChargers(2);
+    // Copy base fields
+    station4.setName(station1.getName());
+    station4.setAddress(station1.getAddress());
+    station4.setCity(station1.getCity());
+    station4.setCountry(station1.getCountry());
+    station4.setLatitude(station1.getLatitude());
+    station4.setLongitude(station1.getLongitude());
+    station4.setStatus(station1.getStatus());
+    assertFalse(station1.equals(station4));
+
+    // Test different quantityOfChargers
+    Station station5 = new Station();
+    station5.setId(1L);
+    station5.setExternalId("ext1");
+    station5.setPower(50);
+    station5.setQuantityOfChargers(4);
+    // Copy base fields
+    station5.setName(station1.getName());
+    station5.setAddress(station1.getAddress());
+    station5.setCity(station1.getCity());
+    station5.setCountry(station1.getCountry());
+    station5.setLatitude(station1.getLatitude());
+    station5.setLongitude(station1.getLongitude());
+    station5.setStatus(station1.getStatus());
+    assertFalse(station1.equals(station5));
+
+    // Test equal stations
+    Station station6 = new Station();
+    station6.setId(1L);
+    station6.setExternalId("ext1");
+    station6.setPower(50);
+    station6.setQuantityOfChargers(2);
+    // Copy base fields
+    station6.setName(station1.getName());
+    station6.setAddress(station1.getAddress());
+    station6.setCity(station1.getCity());
+    station6.setCountry(station1.getCountry());
+    station6.setLatitude(station1.getLatitude());
+    station6.setLongitude(station1.getLongitude());
+    station6.setStatus(station1.getStatus());
+    assertTrue(station1.equals(station6));
+
+    // Test null fields
+    Station station7 = new Station();
+    station7.setId(1L);
+    station7.setExternalId(null);
+    station7.setPower(null);
+    station7.setQuantityOfChargers(null);
+    // Copy base fields
+    station7.setName(station1.getName());
+    station7.setAddress(station1.getAddress());
+    station7.setCity(station1.getCity());
+    station7.setCountry(station1.getCountry());
+    station7.setLatitude(station1.getLatitude());
+    station7.setLongitude(station1.getLongitude());
+    station7.setStatus(station1.getStatus());
+
+    Station station8 = new Station();
+    station8.setId(1L);
+    station8.setExternalId(null);
+    station8.setPower(null);
+    station8.setQuantityOfChargers(null);
+    // Copy base fields
+    station8.setName(station1.getName());
+    station8.setAddress(station1.getAddress());
+    station8.setCity(station1.getCity());
+    station8.setCountry(station1.getCountry());
+    station8.setLatitude(station1.getLatitude());
+    station8.setLongitude(station1.getLongitude());
+    station8.setStatus(station1.getStatus());
+
+    assertTrue(station7.equals(station8));
+  }
+
+  @Test
+  void testHashCode() {
+    Station station1 = new Station();
+    station1.setId(1L);
+    station1.setExternalId("ext1");
+    station1.setPower(50);
+    station1.setQuantityOfChargers(2);
+
+    Station station2 = new Station();
+    station2.setId(1L);
+    station2.setExternalId("ext1");
+    station2.setPower(50);
+    station2.setQuantityOfChargers(2);
+
+    // Equal objects should have equal hash codes
+    assertEquals(station1.hashCode(), station2.hashCode());
+
+    // Test with null fields
+    Station station3 = new Station();
+    station3.setId(1L);
+    station3.setExternalId(null);
+    station3.setPower(null);
+    station3.setQuantityOfChargers(null);
+
+    Station station4 = new Station();
+    station4.setId(1L);
+    station4.setExternalId(null);
+    station4.setPower(null);
+    station4.setQuantityOfChargers(null);
+
+    assertEquals(station3.hashCode(), station4.hashCode());
   }
 }

--- a/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
@@ -2,7 +2,6 @@ package tqs.sparkflow.stationservice.model;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 import jakarta.validation.Validation;
 import jakarta.validation.Validator;

--- a/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/StationTest.java
@@ -317,10 +317,10 @@ class StationTest {
     assertEquals(station1, station1);
 
     // Test null
-    assertNotEquals(station1, null);
+    assertNotEquals(null, station1);
 
     // Test different class
-    assertNotEquals(station1, "Not a Station");
+    assertNotEquals("Not a Station", station1);
 
     // Test different id
     Station station2 = new Station();
@@ -352,7 +352,7 @@ class StationTest {
     station3.setLatitude(station1.getLatitude());
     station3.setLongitude(station1.getLongitude());
     station3.setStatus(station1.getStatus());
-    assertFalse(station1.equals(station3));
+    assertNotEquals(station1, station3);
 
     // Test different power
     Station station4 = new Station();
@@ -400,7 +400,7 @@ class StationTest {
     station6.setLatitude(station1.getLatitude());
     station6.setLongitude(station1.getLongitude());
     station6.setStatus(station1.getStatus());
-    assertTrue(station1.equals(station6));
+    assertEquals(station1, station6);
 
     // Test null fields
     Station station7 = new Station();

--- a/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
@@ -113,11 +113,11 @@ class BookingServiceTest {
                 // Given
                 testStation.setIsOperational(false);
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                LocalDateTime endTime = now.plusHours(2);
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now, endTime,
+                                recurringDays)).isInstanceOf(IllegalStateException.class)
                                                 .hasMessageContaining("Station is not operational");
 
                 verify(bookingRepository, never()).save(any());
@@ -129,11 +129,11 @@ class BookingServiceTest {
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
                 when(bookingRepository.findOverlappingBookings(any(), any(), any()))
                                 .thenReturn(List.of(testBooking));
+                LocalDateTime endTime = now.plusHours(2);
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now, endTime,
+                                recurringDays)).isInstanceOf(IllegalStateException.class)
                                                 .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any());
@@ -194,11 +194,11 @@ class BookingServiceTest {
                 // Given
                 when(restTemplate.getForObject(anyString(), eq(Object.class)))
                                 .thenThrow(new RestClientException("User not found"));
+                LocalDateTime endTime = now.plusHours(2);
 
                 // When & Then
                 assertThatThrownBy(() -> bookingService.createRecurringBooking(99L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
+                                endTime, recurringDays)).isInstanceOf(IllegalStateException.class)
                                                 .hasMessageContaining(
                                                                 "User not found or not authorized");
         }
@@ -322,6 +322,7 @@ class BookingServiceTest {
                 // Given
                 testStation.setQuantityOfChargers(2);
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                LocalDateTime endTime = now.plusHours(2);
 
                 // Two overlapping bookings - all chargers occupied
                 List<Booking> overlappingBookings = List.of(testBooking, testBooking);
@@ -329,9 +330,8 @@ class BookingServiceTest {
                                 .thenReturn(overlappingBookings);
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now, endTime,
+                                recurringDays)).isInstanceOf(IllegalStateException.class)
                                                 .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
@@ -342,15 +342,15 @@ class BookingServiceTest {
                 // Given
                 testStation.setQuantityOfChargers(1);
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                LocalDateTime endTime = now.plusHours(2);
 
                 // One overlapping booking - charger occupied
                 when(bookingRepository.findOverlappingBookings(any(), any(), any()))
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now, endTime,
+                                recurringDays)).isInstanceOf(IllegalStateException.class)
                                                 .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
@@ -360,6 +360,7 @@ class BookingServiceTest {
         void whenCreateBooking_withCancelledBookings_thenThrowException() {
                 // Given
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                LocalDateTime endTime = now.plusHours(2);
 
                 // Create a cancelled booking
                 Booking cancelledBooking = new Booking();
@@ -367,7 +368,7 @@ class BookingServiceTest {
                 cancelledBooking.setStationId(1L);
                 cancelledBooking.setUserId(1L);
                 cancelledBooking.setStartTime(now);
-                cancelledBooking.setEndTime(now.plusHours(2));
+                cancelledBooking.setEndTime(endTime);
                 cancelledBooking.setStatus(BookingStatus.CANCELLED);
 
                 // Mock user validation
@@ -379,9 +380,8 @@ class BookingServiceTest {
                                 .thenReturn(List.of(cancelledBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now, endTime,
+                                recurringDays)).isInstanceOf(IllegalStateException.class)
                                                 .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
@@ -392,15 +392,15 @@ class BookingServiceTest {
                 // Given
                 testStation.setQuantityOfChargers(null);
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                LocalDateTime endTime = now.plusHours(2);
 
                 // One overlapping booking - charger occupied
                 when(bookingRepository.findOverlappingBookings(any(), any(), any()))
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now, endTime,
+                                recurringDays)).isInstanceOf(IllegalStateException.class)
                                                 .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));

--- a/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
@@ -31,6 +31,7 @@ import tqs.sparkflow.stationservice.model.Booking;
 import tqs.sparkflow.stationservice.model.BookingStatus;
 import tqs.sparkflow.stationservice.model.Station;
 import tqs.sparkflow.stationservice.repository.BookingRepository;
+import tqs.sparkflow.stationservice.repository.StationRepository;
 
 /**
  * Comprehensive unit tests for BookingServiceImpl class. Tests all public methods, error scenarios,
@@ -43,7 +44,7 @@ class BookingServiceTest {
         private BookingRepository bookingRepository;
 
         @Mock
-        private StationService stationService;
+        private StationRepository stationRepository;
 
         @Mock
         private RestTemplate restTemplate;
@@ -60,7 +61,7 @@ class BookingServiceTest {
 
         @BeforeEach
         void setUp() {
-                bookingService = new BookingServiceImpl(bookingRepository, stationService,
+                bookingService = new BookingServiceImpl(bookingRepository, stationRepository,
                                 restTemplate, USER_SERVICE_URL);
 
                 now = LocalDateTime.now();
@@ -89,9 +90,9 @@ class BookingServiceTest {
         @DisplayName("Should create recurring booking successfully with valid inputs")
         void whenCreateRecurringBooking_thenReturnCreatedBooking() {
                 // Given
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
-                when(stationService.getStationById(1L)).thenReturn(testStation);
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of());
                 when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
 
                 // When
@@ -103,25 +104,7 @@ class BookingServiceTest {
                 assertThat(createdBooking.getStationId()).isEqualTo(1L);
                 assertThat(createdBooking.getUserId()).isEqualTo(1L);
                 assertThat(createdBooking.getStatus()).isEqualTo(BookingStatus.ACTIVE);
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
                 verify(bookingRepository).save(any(Booking.class));
-        }
-
-        @Test
-        @DisplayName("Should throw exception when user validation fails")
-        void whenCreateRecurringBooking_withInvalidUser_thenThrowException() {
-                // Given
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 999L, Object.class))
-                                .thenThrow(new RestClientException("User not found"));
-
-                // When & Then
-                LocalDateTime endTime = now.plusHours(2);
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(999L, 1L, now,
-                                endTime, recurringDays)).isInstanceOf(IllegalStateException.class)
-                                                .hasMessage("User not found or not authorized");
-
-                verify(stationService, never()).getStationById(any());
-                verify(bookingRepository, never()).save(any());
         }
 
         @Test
@@ -129,46 +112,31 @@ class BookingServiceTest {
         void whenCreateRecurringBooking_withInvalidStation_thenThrowException() {
                 // Given
                 testStation.setIsOperational(false);
-                LocalDateTime end = now.plusHours(2);
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
-                when(stationService.getStationById(1L)).thenReturn(testStation);
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now, end,
-                                recurringDays)).isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
                                                 .hasMessageContaining("Station is not operational");
 
-                verify(stationService, never()).validateBooking(any(), any(), any(), any());
                 verify(bookingRepository, never()).save(any());
         }
 
         @Test
         void whenCreateRecurringBooking_withOverlappingBooking_thenThrowException() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
+                // Given
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of(testBooking));
 
-                // Station setup
-                when(stationService.getStationById(1L)).thenReturn(testStation);
+                // When & Then
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
-                // Configure validateBooking to throw exception for overlapping bookings
-                doThrow(new IllegalStateException(
-                                "No chargers available for the requested time slot"))
-                                                .when(stationService)
-                                                .validateBooking(1L, 1L, now, now.plusHours(2));
-
-                Long userId = 1L;
-                Long stationId = 1L;
-                LocalDateTime endTime = now.plusHours(2);
-                Set<Integer> days = Set.of(1, 2, 3);
-
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(userId, stationId,
-                                now, endTime, days)).isInstanceOf(IllegalStateException.class)
-                                                .hasMessage("No chargers available for the requested time slot");
-
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
-                verify(bookingRepository, never()).save(any(Booking.class));
+                verify(bookingRepository, never()).save(any());
         }
 
         @Test
@@ -223,28 +191,25 @@ class BookingServiceTest {
 
         @Test
         void whenCreateBooking_withUserNotFound_thenThrowException() {
-                // Simulate user validation failure
-                org.mockito.Mockito
-                                .doThrow(new IllegalStateException(
-                                                "User not found or not authorized"))
-                                .when(restTemplate).getForObject(anyString(), eq(Object.class));
-                Booking booking = new Booking();
-                booking.setUserId(99L);
-                booking.setStationId(1L);
-                booking.setStartTime(now);
-                booking.setEndTime(now.plusHours(2));
-                booking.setRecurringDays(recurringDays);
-                assertThatThrownBy(() -> bookingService.createBooking(booking))
-                                .isInstanceOf(IllegalStateException.class)
-                                .hasMessageContaining("User not found or not authorized");
+                // Given
+                when(restTemplate.getForObject(anyString(), eq(Object.class)))
+                                .thenThrow(new RestClientException("User not found"));
+
+                // When & Then
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(99L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessageContaining(
+                                                                "User not found or not authorized");
         }
 
         @Test
         void whenGetAllBookings_withUserNotAuthorized_thenThrowException() {
-                org.mockito.Mockito
-                                .doThrow(new IllegalStateException(
-                                                "User not found or not authorized"))
-                                .when(restTemplate).getForObject(anyString(), eq(Object.class));
+                // Given
+                when(restTemplate.getForObject(anyString(), eq(Object.class)))
+                                .thenThrow(new RestClientException("User not found"));
+
+                // When & Then
                 assertThatThrownBy(() -> bookingService.getAllBookings(99L))
                                 .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
@@ -252,9 +217,11 @@ class BookingServiceTest {
 
         @Test
         void whenGetBookingsByStationId_withUserNotAuthorized_thenThrowException() {
-                when(restTemplate.getForObject(anyString(), eq(Object.class))).thenThrow(
-                                new IllegalStateException("User not found or not authorized"));
+                // Given
+                when(restTemplate.getForObject(anyString(), eq(Object.class)))
+                                .thenThrow(new RestClientException("User not found"));
 
+                // When & Then
                 assertThatThrownBy(() -> bookingService.getBookingsByStationId(99L, 99L))
                                 .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
@@ -262,10 +229,11 @@ class BookingServiceTest {
 
         @Test
         void whenGetBookingsByUserId_withUserNotAuthorized_thenThrowException() {
-                org.mockito.Mockito
-                                .doThrow(new IllegalStateException(
-                                                "User not found or not authorized"))
-                                .when(restTemplate).getForObject(anyString(), eq(Object.class));
+                // Given
+                when(restTemplate.getForObject(anyString(), eq(Object.class)))
+                                .thenThrow(new RestClientException("User not found"));
+
+                // When & Then
                 assertThatThrownBy(() -> bookingService.getBookingsByUserId(99L))
                                 .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
@@ -273,21 +241,19 @@ class BookingServiceTest {
 
         @Test
         void whenGetBookingById_withPermissionDenied_thenThrowException() {
-                // Setup: Create a booking belonging to user 2
+                // Given
                 Booking booking = new Booking();
                 booking.setId(1L);
                 booking.setUserId(2L);
                 when(bookingRepository.findById(1L)).thenReturn(Optional.of(booking));
-
-                // Setup: Mock permission check to fail
-                when(restTemplate.getForObject(anyString(), eq(Boolean.class)))
-                                .thenThrow(new IllegalStateException(
+                when(restTemplate.getForObject(anyString(), eq(Object.class)))
+                                .thenThrow(new RestClientException(
                                                 "User not authorized to access this booking"));
 
-                // Test: Single method invocation that should throw the exception
+                // When & Then
                 assertThatThrownBy(() -> bookingService.getBookingById(1L, 1L))
                                 .isInstanceOf(IllegalStateException.class)
-                                .hasMessageContaining("User not authorized to access this booking");
+                                .hasMessage("User not authorized to access this booking");
         }
 
         @Test
@@ -300,183 +266,142 @@ class BookingServiceTest {
 
         @Test
         void whenCreateRecurringBooking_withNullRecurringDays_thenReturnCreatedBooking() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
-
-                // Station setup
-                when(stationService.getStationById(1L)).thenReturn(testStation);
-
-                // No overlapping bookings - booking should succeed
-                doNothing().when(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
-
+                // Given
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of());
                 when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
 
+                // When
                 Booking result = bookingService.createRecurringBooking(1L, 1L, now,
                                 now.plusHours(2), null);
 
+                // Then
                 assertThat(result).isEqualTo(testBooking);
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
                 verify(bookingRepository).save(any(Booking.class));
         }
 
         @Test
         void whenCreateRecurringBooking_withEmptyRecurringDays_thenReturnCreatedBooking() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
-
-                // Station setup
-                when(stationService.getStationById(1L)).thenReturn(testStation);
-
-                // No overlapping bookings - booking should succeed
-                doNothing().when(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
-
+                // Given
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of());
                 when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
 
+                // When
                 Booking result = bookingService.createRecurringBooking(1L, 1L, now,
                                 now.plusHours(2), Set.of());
 
+                // Then
                 assertThat(result).isEqualTo(testBooking);
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
                 verify(bookingRepository).save(any(Booking.class));
         }
 
         @Test
         void whenCreateBooking_withMultipleChargersAvailable_thenAllowOverlappingBookings() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
-
-                // Station setup
-                when(stationService.getStationById(1L)).thenReturn(testStation);
-
-                // No overlapping bookings - booking should succeed
-                doNothing().when(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
-
+                // Given
+                testStation.setQuantityOfChargers(2);
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of());
                 when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
 
-                Booking result = bookingService.createBooking(testBooking);
+                // When
+                Booking result = bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays);
 
+                // Then
                 assertThat(result).isEqualTo(testBooking);
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
                 verify(bookingRepository).save(any(Booking.class));
         }
 
         @Test
         void whenCreateBooking_withAllChargersOccupied_thenThrowException() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
+                // Given
+                testStation.setQuantityOfChargers(2);
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
 
-                // Station setup
-                when(stationService.getStationById(1L)).thenReturn(testStation);
+                // Two overlapping bookings - all chargers occupied
+                List<Booking> overlappingBookings = List.of(testBooking, testBooking);
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(overlappingBookings);
 
-                // Configure validateBooking to throw exception for no available chargers
-                doThrow(new IllegalStateException(
-                                "No chargers available for the requested time slot"))
-                                                .when(stationService)
-                                                .validateBooking(1L, 1L, now, now.plusHours(2));
+                // When & Then
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
-                assertThatThrownBy(() -> bookingService.createBooking(testBooking))
-                                .isInstanceOf(IllegalStateException.class)
-                                .hasMessage("No chargers available for the requested time slot");
-
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
 
         @Test
         void whenCreateBooking_withSingleChargerStation_thenBlockOverlappingBookings() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
+                // Given
+                testStation.setQuantityOfChargers(1);
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
 
-                // Create a single charger station
-                Station singleChargerStation = new Station();
-                singleChargerStation.setId(1L);
-                singleChargerStation.setQuantityOfChargers(1);
-                singleChargerStation.setIsOperational(true);
+                // One overlapping booking - charger occupied
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of(testBooking));
 
-                when(stationService.getStationById(1L)).thenReturn(singleChargerStation);
+                // When & Then
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
-                // Configure validateBooking to throw exception for single charger station with
-                // overlapping
-                // booking
-                doThrow(new IllegalStateException(
-                                "No chargers available for the requested time slot"))
-                                                .when(stationService)
-                                                .validateBooking(1L, 1L, now, now.plusHours(2));
-
-                assertThatThrownBy(() -> bookingService.createBooking(testBooking))
-                                .isInstanceOf(IllegalStateException.class)
-                                .hasMessage("No chargers available for the requested time slot");
-
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
 
         @Test
-        void whenCreateBooking_withCancelledBookings_thenIgnoreCancelledBookings() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
+        void whenCreateBooking_withCancelledBookings_thenThrowException() {
+                // Given
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
 
-                // Station setup with single charger
-                Station singleChargerStation = new Station();
-                singleChargerStation.setId(1L);
-                singleChargerStation.setQuantityOfChargers(1);
-                singleChargerStation.setIsOperational(true);
-                when(stationService.getStationById(1L)).thenReturn(singleChargerStation);
-
-                // Create a cancelled booking that overlaps with the new booking
+                // Create a cancelled booking
                 Booking cancelledBooking = new Booking();
                 cancelledBooking.setId(2L);
                 cancelledBooking.setStationId(1L);
-                cancelledBooking.setUserId(2L);
+                cancelledBooking.setUserId(1L);
                 cancelledBooking.setStartTime(now);
                 cancelledBooking.setEndTime(now.plusHours(2));
                 cancelledBooking.setStatus(BookingStatus.CANCELLED);
 
-                // No overlapping active bookings - booking should succeed (cancelled bookings are
-                // ignored)
-                doNothing().when(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
+                // Mock user validation
+                when(restTemplate.getForObject(anyString(), eq(Object.class)))
+                                .thenReturn(new Object());
 
-                when(bookingRepository.save(any(Booking.class))).thenReturn(testBooking);
+                // Mock findOverlappingBookings to return the cancelled booking
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of(cancelledBooking));
 
-                Booking result = bookingService.createBooking(testBooking);
+                // When & Then
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
-                assertThat(result).isEqualTo(testBooking);
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
-                verify(bookingRepository).save(any(Booking.class));
+                verify(bookingRepository, never()).save(any(Booking.class));
         }
 
         @Test
         void whenCreateBooking_withNullQuantityOfChargers_thenDefaultToSingleCharger() {
-                // User validation
-                when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
-                                .thenReturn(new Object());
+                // Given
+                testStation.setQuantityOfChargers(null);
+                when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
 
-                // Create station with null quantity of chargers
-                Station nullChargerStation = new Station();
-                nullChargerStation.setId(1L);
-                nullChargerStation.setQuantityOfChargers(null);
-                nullChargerStation.setIsOperational(true);
+                // One overlapping booking - charger occupied
+                when(bookingRepository.findOverlappingBookings(any(), any(), any()))
+                                .thenReturn(List.of(testBooking));
 
-                when(stationService.getStationById(1L)).thenReturn(nullChargerStation);
+                // When & Then
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
-                // Configure validateBooking to throw exception for null charger station (defaults
-                // to 1)
-                doThrow(new IllegalStateException(
-                                "No chargers available for the requested time slot"))
-                                                .when(stationService)
-                                                .validateBooking(1L, 1L, now, now.plusHours(2));
-
-                assertThatThrownBy(() -> bookingService.createBooking(testBooking))
-                                .isInstanceOf(IllegalStateException.class)
-                                .hasMessage("No chargers available for the requested time slot");
-
-                verify(stationService).validateBooking(1L, 1L, now, now.plusHours(2));
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
 }

--- a/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
@@ -115,11 +115,10 @@ class BookingServiceTest {
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
-                                        recurringDays);
-                }).isInstanceOf(IllegalStateException.class)
-                                .hasMessageContaining("Station is not operational");
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessageContaining("Station is not operational");
 
                 verify(bookingRepository, never()).save(any());
         }
@@ -132,11 +131,10 @@ class BookingServiceTest {
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
-                                        recurringDays);
-                }).isInstanceOf(IllegalStateException.class)
-                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any());
         }
@@ -198,11 +196,11 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.createRecurringBooking(99L, 1L, now, now.plusHours(2),
-                                        recurringDays);
-                }).isInstanceOf(IllegalStateException.class)
-                                .hasMessageContaining("User not found or not authorized");
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(99L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessageContaining(
+                                                                "User not found or not authorized");
         }
 
         @Test
@@ -212,9 +210,8 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.getAllBookings(99L);
-                }).isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.getAllBookings(99L))
+                                .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
         }
 
@@ -225,9 +222,8 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.getBookingsByStationId(99L, 99L);
-                }).isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.getBookingsByStationId(99L, 99L))
+                                .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
         }
 
@@ -238,9 +234,8 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.getBookingsByUserId(99L);
-                }).isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.getBookingsByUserId(99L))
+                                .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
         }
 
@@ -256,9 +251,8 @@ class BookingServiceTest {
                                                 "User not authorized to access this booking"));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.getBookingById(1L, 1L);
-                }).isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.getBookingById(1L, 1L))
+                                .isInstanceOf(IllegalStateException.class)
                                 .hasMessage("User not authorized to access this booking");
         }
 
@@ -266,9 +260,8 @@ class BookingServiceTest {
         void whenCancelBooking_withBookingNotFound_thenThrowException() {
                 when(bookingRepository.findById(2L)).thenReturn(Optional.empty());
 
-                assertThatThrownBy(() -> {
-                        bookingService.cancelBooking(2L);
-                }).isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> bookingService.cancelBooking(2L))
+                                .isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("Booking not found");
         }
 
@@ -336,11 +329,10 @@ class BookingServiceTest {
                                 .thenReturn(overlappingBookings);
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
-                                        recurringDays);
-                }).isInstanceOf(IllegalStateException.class)
-                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
@@ -356,11 +348,10 @@ class BookingServiceTest {
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
-                                        recurringDays);
-                }).isInstanceOf(IllegalStateException.class)
-                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
@@ -388,11 +379,10 @@ class BookingServiceTest {
                                 .thenReturn(List.of(cancelledBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
-                                        recurringDays);
-                }).isInstanceOf(IllegalStateException.class)
-                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
@@ -408,11 +398,10 @@ class BookingServiceTest {
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> {
-                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
-                                        recurringDays);
-                }).isInstanceOf(IllegalStateException.class)
-                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
+                                now.plusHours(2), recurringDays))
+                                                .isInstanceOf(IllegalStateException.class)
+                                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }

--- a/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
@@ -3,6 +3,7 @@ package tqs.sparkflow.stationservice.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -13,6 +14,7 @@ import static org.mockito.Mockito.doNothing;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
@@ -52,7 +54,6 @@ class BookingServiceTest {
 
         private static final String USER_SERVICE_URL = "http://test-user-service:8081";
         private static final String USERS_PATH = "/users/";
-        private static final String ADMIN_ROLE_CHECK = "/has-role/ADMIN";
 
         private Booking testBooking;
         private Station testStation;
@@ -423,8 +424,21 @@ class BookingServiceTest {
                 when(restTemplate.getForObject(USER_SERVICE_URL + USERS_PATH + 1L, Object.class))
                                 .thenReturn(new Object());
 
-                // Station setup
-                when(stationService.getStationById(1L)).thenReturn(testStation);
+                // Station setup with single charger
+                Station singleChargerStation = new Station();
+                singleChargerStation.setId(1L);
+                singleChargerStation.setQuantityOfChargers(1);
+                singleChargerStation.setIsOperational(true);
+                when(stationService.getStationById(1L)).thenReturn(singleChargerStation);
+
+                // Create a cancelled booking that overlaps with the new booking
+                Booking cancelledBooking = new Booking();
+                cancelledBooking.setId(2L);
+                cancelledBooking.setStationId(1L);
+                cancelledBooking.setUserId(2L);
+                cancelledBooking.setStartTime(now);
+                cancelledBooking.setEndTime(now.plusHours(2));
+                cancelledBooking.setStatus(BookingStatus.CANCELLED);
 
                 // No overlapping active bookings - booking should succeed (cancelled bookings are
                 // ignored)

--- a/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
@@ -3,7 +3,6 @@ package tqs.sparkflow.stationservice.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -14,7 +13,6 @@ import static org.mockito.Mockito.doNothing;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;

--- a/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
@@ -115,10 +115,11 @@ class BookingServiceTest {
                 when(stationRepository.findById(1L)).thenReturn(Optional.of(testStation));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
-                                                .hasMessageContaining("Station is not operational");
+                assertThatThrownBy(() -> {
+                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
+                                        recurringDays);
+                }).isInstanceOf(IllegalStateException.class)
+                                .hasMessageContaining("Station is not operational");
 
                 verify(bookingRepository, never()).save(any());
         }
@@ -131,10 +132,11 @@ class BookingServiceTest {
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
-                                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> {
+                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
+                                        recurringDays);
+                }).isInstanceOf(IllegalStateException.class)
+                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any());
         }
@@ -196,11 +198,11 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(99L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
-                                                .hasMessageContaining(
-                                                                "User not found or not authorized");
+                assertThatThrownBy(() -> {
+                        bookingService.createRecurringBooking(99L, 1L, now, now.plusHours(2),
+                                        recurringDays);
+                }).isInstanceOf(IllegalStateException.class)
+                                .hasMessageContaining("User not found or not authorized");
         }
 
         @Test
@@ -210,8 +212,9 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.getAllBookings(99L))
-                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> {
+                        bookingService.getAllBookings(99L);
+                }).isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
         }
 
@@ -222,8 +225,9 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.getBookingsByStationId(99L, 99L))
-                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> {
+                        bookingService.getBookingsByStationId(99L, 99L);
+                }).isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
         }
 
@@ -234,8 +238,9 @@ class BookingServiceTest {
                                 .thenThrow(new RestClientException("User not found"));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.getBookingsByUserId(99L))
-                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> {
+                        bookingService.getBookingsByUserId(99L);
+                }).isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("User not found or not authorized");
         }
 
@@ -251,16 +256,19 @@ class BookingServiceTest {
                                                 "User not authorized to access this booking"));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.getBookingById(1L, 1L))
-                                .isInstanceOf(IllegalStateException.class)
+                assertThatThrownBy(() -> {
+                        bookingService.getBookingById(1L, 1L);
+                }).isInstanceOf(IllegalStateException.class)
                                 .hasMessage("User not authorized to access this booking");
         }
 
         @Test
         void whenCancelBooking_withBookingNotFound_thenThrowException() {
                 when(bookingRepository.findById(2L)).thenReturn(Optional.empty());
-                assertThatThrownBy(() -> bookingService.cancelBooking(2L))
-                                .isInstanceOf(IllegalStateException.class)
+
+                assertThatThrownBy(() -> {
+                        bookingService.cancelBooking(2L);
+                }).isInstanceOf(IllegalStateException.class)
                                 .hasMessageContaining("Booking not found");
         }
 
@@ -328,10 +336,11 @@ class BookingServiceTest {
                                 .thenReturn(overlappingBookings);
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
-                                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> {
+                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
+                                        recurringDays);
+                }).isInstanceOf(IllegalStateException.class)
+                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
@@ -347,10 +356,11 @@ class BookingServiceTest {
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
-                                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> {
+                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
+                                        recurringDays);
+                }).isInstanceOf(IllegalStateException.class)
+                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
@@ -378,10 +388,11 @@ class BookingServiceTest {
                                 .thenReturn(List.of(cancelledBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
-                                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> {
+                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
+                                        recurringDays);
+                }).isInstanceOf(IllegalStateException.class)
+                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }
@@ -397,10 +408,11 @@ class BookingServiceTest {
                                 .thenReturn(List.of(testBooking));
 
                 // When & Then
-                assertThatThrownBy(() -> bookingService.createRecurringBooking(1L, 1L, now,
-                                now.plusHours(2), recurringDays))
-                                                .isInstanceOf(IllegalStateException.class)
-                                                .hasMessage("There are overlapping bookings for this time slot");
+                assertThatThrownBy(() -> {
+                        bookingService.createRecurringBooking(1L, 1L, now, now.plusHours(2),
+                                        recurringDays);
+                }).isInstanceOf(IllegalStateException.class)
+                                .hasMessage("There are overlapping bookings for this time slot");
 
                 verify(bookingRepository, never()).save(any(Booking.class));
         }

--- a/src/test/java/tqs/sparkflow/stationservice/service/ChargingSessionServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/ChargingSessionServiceTest.java
@@ -156,7 +156,6 @@ class ChargingSessionServiceTest {
                 // Given
                 String stationId = "1";
                 String userId = "123";
-                LocalDateTime now = LocalDateTime.now();
 
                 ChargingSession session = new ChargingSession(stationId, userId);
 
@@ -165,8 +164,8 @@ class ChargingSessionServiceTest {
                 userBooking.setStationId(Long.valueOf(stationId));
                 userBooking.setUserId(Long.valueOf(userId));
                 userBooking.setStatus(BookingStatus.ACTIVE);
-                userBooking.setStartTime(now.minusMinutes(30));
-                userBooking.setEndTime(now.plusMinutes(30));
+                userBooking.setStartTime(LocalDateTime.now().minusMinutes(30));
+                userBooking.setEndTime(LocalDateTime.now().plusMinutes(30));
 
                 when(chargingSessionRepository.save(any(ChargingSession.class)))
                                 .thenReturn(session);

--- a/src/test/resources/application-test.properties
+++ b/src/test/resources/application-test.properties
@@ -44,3 +44,6 @@ spring.security.oauth2.client.registration.google.provider=google
 # Test user service configuration
 user.service.url=http://mock-user-service
 user.service.api-key=test-api-key
+
+# API paths
+api.paths.users=/users/


### PR DESCRIPTION
This pull request introduces several changes to improve the functionality and maintainability of the `Station` model and associated tests. The most notable updates include implementing `equals` and `hashCode` methods in the `Station` class, enhancing test coverage for booking scenarios, and minor cleanup in test files.

### Updates to the `Station` model:

* [`src/main/java/tqs/sparkflow/stationservice/model/Station.java`](diffhunk://#diff-8b02b2139ad3b5a50116674de074cc8b8884ac31b35147ed12ae9f3aadc9d0b9R171-R189): Added `equals` and `hashCode` methods to ensure proper comparison and hashing of `Station` objects based on their attributes. This improves consistency when using `Station` instances in collections or performing equality checks.

### Enhancements to test coverage:

* [`src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java`](diffhunk://#diff-ed79d1cc712dff37995f2c2623f8a7f7f9c950217a3691424bbb480b6508a056L426-R441): Updated the `whenCreateBooking_withCancelledBookings_thenIgnoreCancelledBookings` test to include scenarios with cancelled bookings and single-charger stations, ensuring that cancelled bookings are ignored during booking creation.

### Minor cleanup and improvements:

* [`src/main/java/tqs/sparkflow/stationservice/model/Station.java`](diffhunk://#diff-8b02b2139ad3b5a50116674de074cc8b8884ac31b35147ed12ae9f3aadc9d0b9L11-R13): Removed unused `@NotBlank` import and added `Objects` import for utility methods used in `equals` and `hashCode`.
* [`src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java`](diffhunk://#diff-ed79d1cc712dff37995f2c2623f8a7f7f9c950217a3691424bbb480b6508a056L55): Removed unused constant `ADMIN_ROLE_CHECK` and added `Collections` import for test setup. [[1]](diffhunk://#diff-ed79d1cc712dff37995f2c2623f8a7f7f9c950217a3691424bbb480b6508a056L55) [[2]](diffhunk://#diff-ed79d1cc712dff37995f2c2623f8a7f7f9c950217a3691424bbb480b6508a056R17)
* [`src/test/java/tqs/sparkflow/stationservice/service/ChargingSessionServiceTest.java`](diffhunk://#diff-6deade9d0e49b787b443031db91a308657d8f3621d64c9b9cf065b614c2ddafdL159): Simplified date-time handling in `whenCreateSession_thenClosesUserBooking` by directly invoking `LocalDateTime.now()` instead of storing it in a variable. [[1]](diffhunk://#diff-6deade9d0e49b787b443031db91a308657d8f3621d64c9b9cf065b614c2ddafdL159) [[2]](diffhunk://#diff-6deade9d0e49b787b443031db91a308657d8f3621d64c9b9cf065b614c2ddafdL168-R168)