### PR TITLE
Enhance V2__create_test_stations.sql by introducing constants for com…

### DIFF
--- a/src/main/resources/db/migration/V2__create_test_stations.sql
+++ b/src/main/resources/db/migration/V2__create_test_stations.sql
@@ -1,3 +1,8 @@
+-- Define constants for common values
+\set COUNTRY 'Portugal'
+\set STATUS 'Available'
+\set OPERATIONAL true
+
 -- Insert test charging stations along Porto to Lisbon route
 INSERT INTO stations (
     name, 
@@ -15,8 +20,8 @@ INSERT INTO stations (
     min_power,
     max_power
 ) VALUES
-('Porto Central Station', 'Rua Central 123', 'Porto', 'Portugal', 41.1579, -8.6291, 'Available', 2, 50, true, 0.25, 2, 22, 50),
-('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', 'Portugal', 40.6443, -8.6455, 'Available', 3, 150, true, 0.30, 3, 50, 150),
-('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', 'Portugal', 40.2033, -8.4103, 'Available', 4, 250, true, 0.35, 4, 150, 250),
-('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', 'Portugal', 39.7477, -8.8070, 'Available', 2, 100, true, 0.28, 2, 50, 100),
-('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', 'Portugal', 38.7223, -9.1393, 'Available', 3, 150, true, 0.30, 3, 50, 150); 
+('Porto Central Station', 'Rua Central 123', 'Porto', :'COUNTRY', 41.1579, -8.6291, :'STATUS', 2, 50, :'OPERATIONAL', 0.25, 2, 22, 50),
+('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', :'COUNTRY', 40.6443, -8.6455, :'STATUS', 3, 150, :'OPERATIONAL', 0.30, 3, 50, 150),
+('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', :'COUNTRY', 40.2033, -8.4103, :'STATUS', 4, 250, :'OPERATIONAL', 0.35, 4, 150, 250),
+('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', :'COUNTRY', 39.7477, -8.8070, :'STATUS', 2, 100, :'OPERATIONAL', 0.28, 2, 50, 100),
+('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', :'COUNTRY', 38.7223, -9.1393, :'STATUS', 3, 150, :'OPERATIONAL', 0.30, 3, 50, 150); 

--- a/src/main/resources/db/migration/V2__create_test_stations.sql
+++ b/src/main/resources/db/migration/V2__create_test_stations.sql
@@ -1,9 +1,10 @@
--- Define constants for common values
-\set COUNTRY 'Portugal'
-\set STATUS 'Available'
-\set OPERATIONAL true
-
 -- Insert test charging stations along Porto to Lisbon route
+WITH constants AS (
+    SELECT 
+        'Portugal' as country,
+        'Available' as status,
+        true as operational
+)
 INSERT INTO stations (
     name, 
     address, 
@@ -19,9 +20,30 @@ INSERT INTO stations (
     number_of_chargers,
     min_power,
     max_power
-) VALUES
-('Porto Central Station', 'Rua Central 123', 'Porto', :'COUNTRY', 41.1579, -8.6291, :'STATUS', 2, 50, :'OPERATIONAL', 0.25, 2, 22, 50),
-('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', :'COUNTRY', 40.6443, -8.6455, :'STATUS', 3, 150, :'OPERATIONAL', 0.30, 3, 50, 150),
-('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', :'COUNTRY', 40.2033, -8.4103, :'STATUS', 4, 250, :'OPERATIONAL', 0.35, 4, 150, 250),
-('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', :'COUNTRY', 39.7477, -8.8070, :'STATUS', 2, 100, :'OPERATIONAL', 0.28, 2, 50, 100),
-('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', :'COUNTRY', 38.7223, -9.1393, :'STATUS', 3, 150, :'OPERATIONAL', 0.30, 3, 50, 150); 
+)
+SELECT 
+    name,
+    address,
+    city,
+    c.country,
+    latitude,
+    longitude,
+    c.status,
+    quantity_of_chargers,
+    power,
+    c.operational,
+    price,
+    number_of_chargers,
+    min_power,
+    max_power
+FROM constants c
+CROSS JOIN (VALUES
+    ('Porto Central Station', 'Rua Central 123', 'Porto', 41.1579, -8.6291, 2, 50, 0.25, 2, 22, 50),
+    ('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', 40.6443, -8.6455, 3, 150, 0.30, 3, 50, 150),
+    ('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', 40.2033, -8.4103, 4, 250, 0.35, 4, 150, 250),
+    ('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', 39.7477, -8.8070, 2, 100, 0.28, 2, 50, 100),
+    ('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', 38.7223, -9.1393, 3, 150, 0.30, 3, 50, 150)
+) AS stations_data (
+    name, address, city, latitude, longitude, 
+    quantity_of_chargers, power, price, number_of_chargers, min_power, max_power
+); 

--- a/src/test/java/tqs/sparkflow/stationservice/model/BaseStationFieldsTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/model/BaseStationFieldsTest.java
@@ -69,8 +69,8 @@ class BaseStationFieldsTest {
   @Test
   void whenSettingValidLongitude_thenNoValidationErrors() {
     // Given
-    baseFields.setLatitude(41.1579); // Required field
-    baseFields.setLongitude(-8.6291);
+    baseFields.setLatitude(38.7223); // Different latitude value
+    baseFields.setLongitude(-9.1393); // Different longitude value
     baseFields.setStatus("Available"); // Required field
 
     // When
@@ -78,6 +78,7 @@ class BaseStationFieldsTest {
 
     // Then
     assertThat(violations).isEmpty();
+    assertThat(baseFields.getLongitude()).isEqualTo(-9.1393);
   }
 
   @Test

--- a/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java
@@ -5,11 +5,9 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.doNothing;
 
 import java.time.LocalDateTime;
 import java.util.Arrays;

--- a/src/test/java/tqs/sparkflow/stationservice/service/ChargingSessionServiceTest.java
+++ b/src/test/java/tqs/sparkflow/stationservice/service/ChargingSessionServiceTest.java
@@ -198,7 +198,6 @@ class ChargingSessionServiceTest {
                 // Given
                 String stationId = "1";
                 String userId = "123";
-                LocalDateTime now = LocalDateTime.now();
 
                 ChargingSession session = new ChargingSession(stationId, userId);
 


### PR DESCRIPTION
This pull request introduces improvements to the codebase by enhancing maintainability and simplifying test logic. The most significant changes include the introduction of constants in SQL scripts to reduce duplication, updates to test files to remove unused imports, and minor cleanup in test methods.

### SQL script improvements:
* [`src/main/resources/db/migration/V2__create_test_stations.sql`](diffhunk://#diff-e7d6df2f4efb93797c0b3388410d1e38c3840963161d95771bc91b04e58f2480R1-R5): Introduced constants (`COUNTRY`, `STATUS`, `OPERATIONAL`) to eliminate repeated values in the `INSERT INTO stations` statements, improving readability and maintainability. [[1]](diffhunk://#diff-e7d6df2f4efb93797c0b3388410d1e38c3840963161d95771bc91b04e58f2480R1-R5) [[2]](diffhunk://#diff-e7d6df2f4efb93797c0b3388410d1e38c3840963161d95771bc91b04e58f2480L18-R27)

### Test file cleanup:
* [`src/test/java/tqs/sparkflow/stationservice/service/BookingServiceTest.java`](diffhunk://#diff-ed79d1cc712dff37995f2c2623f8a7f7f9c950217a3691424bbb480b6508a056L8-L12): Removed unused imports (`doThrow`, `doNothing`) to clean up the test file.
* [`src/test/java/tqs/sparkflow/stationservice/service/ChargingSessionServiceTest.java`](diffhunk://#diff-6deade9d0e49b787b443031db91a308657d8f3621d64c9b9cf065b614c2ddafdL201): Removed an unused variable (`LocalDateTime now`) from the `whenCreateSession_withMultipleBookings_thenClosesOnlyUserBooking` test method to simplify the code.