### PR TITLE
Refactor V2__create_test_stations.sql to eliminate the common constan…

### DIFF
--- a/src/main/resources/db/migration/V2__create_test_stations.sql
+++ b/src/main/resources/db/migration/V2__create_test_stations.sql
@@ -1,10 +1,9 @@
+-- Define constants for common values
+SET @COUNTRY = 'Portugal';
+SET @STATUS = 'Available';
+SET @OPERATIONAL = true;
+
 -- Insert test charging stations along Porto to Lisbon route
-WITH constants AS (
-    SELECT 
-        'Portugal' as country,
-        'Available' as status,
-        true as operational
-)
 INSERT INTO stations (
     name, 
     address, 
@@ -20,30 +19,9 @@ INSERT INTO stations (
     number_of_chargers,
     min_power,
     max_power
-)
-SELECT 
-    name,
-    address,
-    city,
-    c.country,
-    latitude,
-    longitude,
-    c.status,
-    quantity_of_chargers,
-    power,
-    c.operational,
-    price,
-    number_of_chargers,
-    min_power,
-    max_power
-FROM constants c
-CROSS JOIN (VALUES
-    ('Porto Central Station', 'Rua Central 123', 'Porto', 41.1579, -8.6291, 2, 50, 0.25, 2, 22, 50),
-    ('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', 40.6443, -8.6455, 3, 150, 0.30, 3, 50, 150),
-    ('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', 40.2033, -8.4103, 4, 250, 0.35, 4, 150, 250),
-    ('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', 39.7477, -8.8070, 2, 100, 0.28, 2, 50, 100),
-    ('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', 38.7223, -9.1393, 3, 150, 0.30, 3, 50, 150)
-) AS stations_data (
-    name, address, city, latitude, longitude, 
-    quantity_of_chargers, power, price, number_of_chargers, min_power, max_power
-); 
+) VALUES
+('Porto Central Station', 'Rua Central 123', 'Porto', @COUNTRY, 41.1579, -8.6291, @STATUS, 2, 50, @OPERATIONAL, 0.25, 2, 22, 50),
+('Aveiro Charging Hub', 'Avenida Principal 45', 'Aveiro', @COUNTRY, 40.6443, -8.6455, @STATUS, 3, 150, @OPERATIONAL, 0.30, 3, 50, 150),
+('Coimbra Supercharger', 'Rua da Universidade 78', 'Coimbra', @COUNTRY, 40.2033, -8.4103, @STATUS, 4, 250, @OPERATIONAL, 0.35, 4, 150, 250),
+('Leiria Fast Charge', 'Avenida da Liberdade 90', 'Leiria', @COUNTRY, 39.7477, -8.8070, @STATUS, 2, 100, @OPERATIONAL, 0.28, 2, 50, 100),
+('Lisbon Central Station', 'Avenida da República 150', 'Lisbon', @COUNTRY, 38.7223, -9.1393, @STATUS, 3, 150, @OPERATIONAL, 0.30, 3, 50, 150); 


### PR DESCRIPTION
This pull request refactors the SQL script for creating test charging stations by simplifying the insertion logic and improving maintainability. The most important changes include replacing the `WITH constants` clause with predefined constants and directly embedding these constants in the `VALUES` clause for station data.

Refactoring for maintainability:

* **Defined constants for common values**: Added `SET` statements to define reusable constants (`@COUNTRY`, `@STATUS`, and `@OPERATIONAL`) for common values used in the station data. This eliminates the need for the `WITH constants` clause. (`src/main/resources/db/migration/V2__create_test_stations.sql`, [src/main/resources/db/migration/V2__create_test_stations.sqlR1-L7](diffhunk://#diff-e7d6df2f4efb93797c0b3388410d1e38c3840963161d95771bc91b04e58f2480R1-L7))

Simplification of insertion logic:

* **Replaced `WITH constants` and `CROSS JOIN` with direct `VALUES` clause**: Simplified the insertion logic by directly using the predefined constants in the `VALUES` clause, removing the need for a `CROSS JOIN` operation with a `constants` table. (`src/main/resources/db/migration/V2__create_test_stations.sql`, [src/main/resources/db/migration/V2__create_test_stations.sqlL23-R27](diffhunk://#diff-e7d6df2f4efb93797c0b3388410d1e38c3840963161d95771bc91b04e58f2480L23-R27))